### PR TITLE
Setup aws alias for aws vault

### DIFF
--- a/.aliases.d/composer
+++ b/.aliases.d/composer
@@ -5,4 +5,4 @@
 alias composer=""
 unalias composer
 ## Run composer without memory limits
-alias composer="php -d memory_limit=-1 `which composer`"
+alias composer="php -d memory_limit=-1 -d xdebug.remote_autostart=0 `which composer`"

--- a/.bin/aws
+++ b/.bin/aws
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+PROFILE="${AWS_PROFILE:-${AWS_DEFAULT_PROFILE:-ro}}"
+
+(>&2 echo "Executing aws command using '${PROFILE}' profile.")
+
+exec /usr/local/bin/aws-vault exec "${PROFILE}" -- /usr/local/bin/aws "$@"


### PR DESCRIPTION
Adds an `aws` script file that can be used instead of the default `aws` command, to allow use of `aws-vault` profiles to be applied to `aws` commands.